### PR TITLE
format with %08x not handling numbers greater than 32bit int

### DIFF
--- a/md5.lua
+++ b/md5.lua
@@ -413,7 +413,7 @@ function md5.new()
 end
 
 function md5.tohex(s)
-  return format("%08x%08x%08x%08x", str2bei(sub(s, 1, 4)), str2bei(sub(s, 5, 8)), str2bei(sub(s, 9, 12)), str2bei(sub(s, 13, 16)))
+  return format("%04x%04x%04x%04x%04x%04x%04x%04x", str2bei(sub(s, 1, 2)), str2bei(sub(s, 3, 4)), str2bei(sub(s, 5, 6)), str2bei(sub(s, 7, 8)), str2bei(sub(s, 9, 10)), str2bei(sub(s, 11, 12)), str2bei(sub(s, 13, 14)), str2bei(sub(s, 15, 16)))
 end
 
 function md5.sum(s)


### PR DESCRIPTION
I have a device (aarch64 cortex-a53) running OpenWRT and lua 5.1.5

`Lua 5.1.5  Copyright (C) 1994-2012 Lua.org, PUC-Rio (double int32)`

When using the md5 library to hash a message I got the following error

```
usr/bin/lua: ./md5.lua:416: bad argument #3 to 'format' (integer expected, got number)
stack traceback:
       [C]: in function 'format'
       ./md5.lua:416: in function 'tohex'
```

Changing `format()` from `%08x` with 4 bits to `%04x` with 2 bits fixed the execution